### PR TITLE
Include warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luminateone/eslint-baseline",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "create a baseline for eslint pipelines",
   "main": "index.js",
   "type": "module",

--- a/src/eslint.js
+++ b/src/eslint.js
@@ -29,7 +29,7 @@ async function execute(args = []) {
     json.forEach((file) => {
 
         file.messages.forEach((message) => {
-            if (message.severity >= 2) {
+            if (message.severity >= 1) {
 
                 let filePath = path.relative(process.cwd(), file.filePath);
 


### PR DESCRIPTION
This is a simple, single line change that makes this package include both warnings and errors instead of just errors.

Forked from upstream as it's very likely the dev is AFK and this is pretty quick.

May later handle this upstream or push this to an internal package registry (npm, GH packages, whatever).

For now just going to include this directly inside the api repo.